### PR TITLE
fix(return-main-err): fixes error messages length txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-rollup-nuxt-core",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -168,7 +168,8 @@ export function filterError(error: Error): string | undefined {
     } else if (error.message.includes("Fee is to low")) {
       return "Transaction fee was to low. Try again.";
     }
-    return error.message;
+    const msg = error.message.substring(0, error.message.indexOf("("));
+    return msg ? msg : error.message;
   }
   return "Unknown error";
 }


### PR DESCRIPTION
This PR aims to implement a more broader solution for returning the main error message of a failed transaction instead of the entire error stack.